### PR TITLE
Replace nose test assertions with pytest assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Use pytest instead of nosetest for assertions.
+- Drop dependency on `more_assertive_nose` library.
+
+## 0.0.1 - 2018-02-21
+
+- Initial version


### PR DESCRIPTION
- Use pytest instead of nosetest for assertions.
- Drop dependency on `more_assertive_nose` library.